### PR TITLE
Provide desktop launcher file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ package-lock.json
 strongs_todo.txt
 .DS_Store
 complexity_metrics.html
+tags

--- a/ezra-project.desktop
+++ b/ezra-project.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Ezra Project
+GenericName=Bible Study Tool
+Comment=Bible study tool focussing on topical study based on keywords/tags
+Exec=ezra-project
+Icon=ezra-project
+Terminal=false
+StartupNotify=false
+Categories=Education;Spirituality;Literature;

--- a/package_config/deb_config_debian10.json
+++ b/package_config/deb_config_debian10.json
@@ -2,13 +2,13 @@
   "dest": "release/packages/",
   "categories": [
     "Education",
-    "Utility",
-    "Spirituality"
+    "Spirituality",
+    "Literature"
   ],
   "name": "ezra-project",
   "productName": "Ezra Project",
   "genericName": "Bible Study Tool",
-  "description": "Ezra Project is a Bible study tool focussing on topical study based on keywords/tags.",
+  "description": "Ezra Project is a Bible study tool focussing on topical study based on keywords/tags",
   "productDescription": "Ezra Project is a Bible study tool focussing on topical study based on keywords/tags. This program helps the user to easily create and manage topical verse lists. Ezra Project works with SWORD Bible translation modules and thus enables Bible study in many languages.",
   "depends": [
     "libicu63",

--- a/package_config/deb_config_mint18.json
+++ b/package_config/deb_config_mint18.json
@@ -2,13 +2,13 @@
   "dest": "release/packages/",
   "categories": [
     "Education",
-    "Utility",
-    "Spirituality"
+    "Spirituality",
+    "Literature"
   ],
   "name": "ezra-project",
   "productName": "Ezra Project",
   "genericName": "Bible Study Tool",
-  "description": "Ezra Project is a Bible study tool focussing on topical study based on keywords/tags.",
+  "description": "Ezra Project is a Bible study tool focussing on topical study based on keywords/tags",
   "productDescription": "Ezra Project is a Bible study tool focussing on topical study based on keywords/tags. This program helps the user to easily create and manage topical verse lists. Ezra Project works with SWORD Bible translation modules and thus enables Bible study in many languages.",
   "depends": [
     "libicu55",

--- a/package_config/deb_config_ubuntu1804.json
+++ b/package_config/deb_config_ubuntu1804.json
@@ -2,13 +2,13 @@
   "dest": "release/packages/",
   "categories": [
     "Education",
-    "Utility",
-    "Spirituality"
+    "Spirituality",
+    "Literature"
   ],
   "name": "ezra-project",
   "productName": "Ezra Project",
   "genericName": "Bible Study Tool",
-  "description": "Ezra Project is a Bible study tool focussing on topical study based on keywords/tags.",
+  "description": "Ezra Project is a Bible study tool focussing on topical study based on keywords/tags",
   "productDescription": "Ezra Project is a Bible study tool focussing on topical study based on keywords/tags. This program helps the user to easily create and manage topical verse lists. Ezra Project works with SWORD Bible translation modules and thus enables Bible study in many languages.",
   "depends": [
     "libicu60",

--- a/package_config/deb_config_ubuntu1904.json
+++ b/package_config/deb_config_ubuntu1904.json
@@ -2,13 +2,13 @@
   "dest": "release/packages/",
   "categories": [
     "Education",
-    "Utility",
-    "Spirituality"
+    "Spirituality",
+    "Literature"
   ],
   "name": "ezra-project",
   "productName": "Ezra Project",
   "genericName": "Bible Study Tool",
-  "description": "Ezra Project is a Bible study tool focussing on topical study based on keywords/tags.",
+  "description": "Ezra Project is a Bible study tool focussing on topical study based on keywords/tags",
   "productDescription": "Ezra Project is a Bible study tool focussing on topical study based on keywords/tags. This program helps the user to easily create and manage topical verse lists. Ezra Project works with SWORD Bible translation modules and thus enables Bible study in many languages.",
   "depends": [
     "libicu63",

--- a/package_config/rpm_config_centos.json
+++ b/package_config/rpm_config_centos.json
@@ -2,13 +2,13 @@
   "dest": "release/packages/",
   "categories": [
     "Education",
-    "Utility",
-    "Spirituality"
+    "Spirituality",
+    "Literature"
   ],
   "name": "ezra-project",
   "productName": "Ezra Project",
   "genericName": "Bible Study Tool",
-  "description": "Ezra Project is a Bible study tool focussing on topical study based on keywords/tags.",
+  "description": "Ezra Project is a Bible study tool focussing on topical study based on keywords/tags",
   "productDescription": "Ezra Project is a Bible study tool focussing on topical study based on keywords/tags. This program helps the user to easily create and manage topical verse lists. Ezra Project works with SWORD Bible translation modules and thus enables Bible study in many languages.",
   "requires": [
       "libicu",

--- a/package_config/rpm_config_fedora29.json
+++ b/package_config/rpm_config_fedora29.json
@@ -2,13 +2,13 @@
   "dest": "release/packages/",
   "categories": [
     "Education",
-    "Utility",
-    "Spirituality"
+    "Spirituality",
+    "Literature"
   ],
   "name": "ezra-project",
   "productName": "Ezra Project",
   "genericName": "Bible Study Tool",
-  "description": "Ezra Project is a Bible study tool focussing on topical study based on keywords/tags.",
+  "description": "Ezra Project is a Bible study tool focussing on topical study based on keywords/tags",
   "productDescription": "Ezra Project is a Bible study tool focussing on topical study based on keywords/tags. This program helps the user to easily create and manage topical verse lists. Ezra Project works with SWORD Bible translation modules and thus enables Bible study in many languages.",
   "requires": [
       "(libicu or compat-libicu62)",

--- a/package_config/rpm_config_opensuse_leap.json
+++ b/package_config/rpm_config_opensuse_leap.json
@@ -2,13 +2,13 @@
   "dest": "release/packages/",
   "categories": [
     "Education",
-    "Utility",
-    "Spirituality"
+    "Spirituality",
+    "Literature"
   ],
   "name": "ezra-project",
   "productName": "Ezra Project",
   "genericName": "Bible Study Tool",
-  "description": "Ezra Project is a Bible study tool focussing on topical study based on keywords/tags.",
+  "description": "Ezra Project is a Bible study tool focussing on topical study based on keywords/tags",
   "productDescription": "Ezra Project is a Bible study tool focussing on topical study based on keywords/tags. This program helps the user to easily create and manage topical verse lists. Ezra Project works with SWORD Bible translation modules and thus enables Bible study in many languages.",
   "requires": [
       "libicu60_2",


### PR DESCRIPTION
This file is easily generated. My own packaging generates it at build time:

```sh
gendesk -f -n --pkgname ezra-project --pkgdesc ezra-project --name "Ezra Project"
```

Also I believe most stock Electron has some facility for creating launchers if none exist.

The advantage of providing it in the upstream project is that this opens the door to more features:

* A desktop icon can be specified.
* The launcher itself can have localized strings for different languages.

This will also add a little bit of consistency across distros/package systems.

I don't know what needs to be done to tell your other electron packaging to use this, but for my own purposes packaging on Arch just including the source file in the repo somewhere is enough.